### PR TITLE
[fix] deprecated uuid deep require

### DIFF
--- a/backend/services/file.js
+++ b/backend/services/file.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const uuidv4 = require('uuid/v4')
+const { v4: uuidv4 } = require('uuid')
 
 
 // Promise delay function


### PR DESCRIPTION
# Description
Fixing deprecation with the uuid library. uuid library deprecated the deep require in favor of destructured import.

>As of uuid@7 this library now provides ECMAScript modules builds, which allow packagers like Webpack and Rollup to do "tree-shaking" to remove dead code. Instead, use the import syntax:

```js
const { v4: uuidv4 } = require('uuid');
uuidv4();
```

Reference - https://github.com/uuidjs/uuid#deep-requires-now-deprecated 
